### PR TITLE
cleanup usage of __super with base declaration

### DIFF
--- a/prog/tools/AssetViewer/FastPhys/fastPhysChar.h
+++ b/prog/tools/AssetViewer/FastPhys/fastPhysChar.h
@@ -37,7 +37,7 @@ public:
   virtual void setMatrix(const Matrix3 &tm);
   virtual void setWtm(const TMatrix &wtm);
 
-  EO_IMPLEMENT_RTTI(HUID)
+  EO_IMPLEMENT_RTTI(HUID, RenderableEditableObject)
 
   // default implementation for some inherited methods
   virtual bool mayDelete() { return false; }

--- a/prog/tools/AssetViewer/FastPhys/fastPhysObject.h
+++ b/prog/tools/AssetViewer/FastPhys/fastPhysObject.h
@@ -17,6 +17,8 @@ public:
   static E3DCOLOR frozenColor;
 
 public:
+  EO_IMPLEMENT_RTTI(HUID, RenderableEditableObject)
+  
   IFPObject(FpdObject *obj, FastPhysEditor &editor);
   virtual ~IFPObject();
 
@@ -40,7 +42,6 @@ public:
   virtual void onPPChange(int pid, bool edit_finished, PropertyContainerControlBase &panel,
     dag::ConstSpan<RenderableEditableObject *> objects){};
 
-  EO_IMPLEMENT_RTTI(HUID)
 
 protected:
   Ptr<FpdObject> mObject;

--- a/prog/tools/AssetViewer/av_viewportWindow.cpp
+++ b/prog/tools/AssetViewer/av_viewportWindow.cpp
@@ -34,7 +34,7 @@ AssetViewerViewportWindow::AssetViewerViewportWindow(TEcHandle parent, int left,
 
 void AssetViewerViewportWindow::load(const DataBlock &blk)
 {
-  __super::load(blk);
+  ViewportWindow::load(blk);
 
   showAssetStats = blk.getBool("show_asset_stats", false);
 
@@ -58,7 +58,7 @@ void AssetViewerViewportWindow::load(const DataBlock &blk)
 
 void AssetViewerViewportWindow::save(DataBlock &blk) const
 {
-  __super::save(blk);
+  ViewportWindow::save(blk);
 
   blk.setBool("show_asset_stats", showAssetStats);
 
@@ -124,7 +124,7 @@ void AssetViewerViewportWindow::paint(int w, int h)
 {
   using hdpi::_pxScaled;
 
-  __super::paint(w, h);
+  ViewportWindow::paint(w, h);
 
   if (!needShowAssetStats())
     return;
@@ -176,7 +176,7 @@ void AssetViewerViewportWindow::paint(int w, int h)
 
 void AssetViewerViewportWindow::fillStatSettingsDialog(PropertyContainerControlBase &tab_panel)
 {
-  __super::fillStatSettingsDialog(tab_panel);
+  ViewportWindow::fillStatSettingsDialog(tab_panel);
 
   PropertyContainerControlBase *mainTabPage = tab_panel.getContainerById(CM_STATS_SETTINGS_MAIN_PAGE);
   G_ASSERT(mainTabPage);
@@ -200,7 +200,7 @@ void AssetViewerViewportWindow::handleStatSettingsDialogChange(int pcb_id)
   else if (pcb_id == CM_STATS_SETTINGS_MAIN_SHOW_ASSETS_STATS)
     showAssetStats = !showAssetStats;
   else
-    __super::handleStatSettingsDialogChange(pcb_id);
+    ViewportWindow::handleStatSettingsDialogChange(pcb_id);
 }
 
 int AssetViewerViewportWindow::getAssetStatByIndex(int index)

--- a/prog/tools/sceneTools/daEditorX/HeightmapLand/hmlEntity.h
+++ b/prog/tools/sceneTools/daEditorX/HeightmapLand/hmlEntity.h
@@ -17,6 +17,7 @@ static constexpr unsigned CID_LandscapeEntityObject = 0xE79DC1EDu; // LandscapeE
 class LandscapeEntityObject : public RenderableEditableObject
 {
 public:
+  EO_IMPLEMENT_RTTI(CID_LandscapeEntityObject, RenderableEditableObject)
   LandscapeEntityObject(const char *ent_name, int rnd_seed = 0);
 
   virtual void update(float) {}
@@ -50,7 +51,6 @@ public:
 
   virtual void onObjectNameChange(RenderableEditableObject *obj, const char *old_name, const char *new_name) { objectPropsChanged(); }
 
-  EO_IMPLEMENT_RTTI(CID_LandscapeEntityObject)
 
   UndoRedoObject *makePropsUndoObj() { return new UndoPropsChange(this); }
   void renderBox();

--- a/prog/tools/sceneTools/daEditorX/HeightmapLand/hmlHoleObject.h
+++ b/prog/tools/sceneTools/daEditorX/HeightmapLand/hmlHoleObject.h
@@ -17,6 +17,8 @@ class HmapLandHoleObject : public RenderableEditableObject
 {
 public:
   Point3 boxSize;
+  
+  EO_IMPLEMENT_RTTI(CID_HmapLandHoleObject, RenderableEditableObject)
 
   HmapLandHoleObject();
 
@@ -43,7 +45,6 @@ public:
   virtual void load(const DataBlock &blk);
 
 
-  EO_IMPLEMENT_RTTI(CID_HmapLandHoleObject)
 
 
   void buildBoxEdges(IGenViewportWnd *vp, Point2 edges[12][2]) const;

--- a/prog/tools/sceneTools/daEditorX/HeightmapLand/hmlSnow.h
+++ b/prog/tools/sceneTools/daEditorX/HeightmapLand/hmlSnow.h
@@ -16,6 +16,8 @@ class SnowSourceObject : public RenderableEditableObject
 {
 public:
   SnowSourceObject();
+  
+  EO_IMPLEMENT_RTTI(CID_SnowSourceObject, RenderableEditableObject)
 
   virtual void update(float) {}
   virtual void beforeRender() {}
@@ -46,7 +48,6 @@ public:
 
   virtual void onObjectNameChange(RenderableEditableObject *obj, const char *old_name, const char *new_name) {}
 
-  EO_IMPLEMENT_RTTI(CID_SnowSourceObject)
 
   UndoRedoObject *makePropsUndoObj() { return new UndoPropsChange(this); }
   SnowSourceObject *clone();

--- a/prog/tools/sceneTools/daEditorX/HeightmapLand/hmlSplineObject.h
+++ b/prog/tools/sceneTools/daEditorX/HeightmapLand/hmlSplineObject.h
@@ -123,7 +123,7 @@ public:
   virtual void onAdd(ObjectEditor *objEditor);
   virtual Point3 getPos() const { return splineCenter(); }
 
-  EO_IMPLEMENT_RTTI(CID_HMapSplineObject);
+  EO_IMPLEMENT_RTTI(CID_HMapSplineObject, RenderableEditableObject);
 
 
   void getSpline();

--- a/prog/tools/sceneTools/daEditorX/HeightmapLand/hmlSplinePoint.h
+++ b/prog/tools/sceneTools/daEditorX/HeightmapLand/hmlSplinePoint.h
@@ -75,6 +75,8 @@ protected:
   ~SplinePointObject();
 
 public:
+  EO_IMPLEMENT_RTTI(CID_SplinePointObject, RenderableEditableObject)
+  
   SplinePointObject();
 
   virtual void update(float) {}
@@ -115,7 +117,6 @@ public:
 
   virtual bool setPos(const Point3 &p);
 
-  EO_IMPLEMENT_RTTI(CID_SplinePointObject)
 
   Point3 getPt() const { return props.pt; }
   Point3 getBezierIn() const { return props.pt + getPtEffRelBezierIn(); }

--- a/prog/tools/sceneTools/daEditorX/IvyGen/ivyObject.h
+++ b/prog/tools/sceneTools/daEditorX/IvyGen/ivyObject.h
@@ -241,7 +241,7 @@ public:
   virtual bool mayRename() { return true; }
   virtual bool mayDelete() { return true; }
 
-  EO_IMPLEMENT_RTTI(CID_IvyObject)
+  EO_IMPLEMENT_RTTI(CID_IvyObject, RenderableEditableObject)
 
   int getUid() const { return uid; }
   Point3 getPt() const { return pt; }

--- a/prog/tools/sceneTools/daEditorX/Occluders/occluder.h
+++ b/prog/tools/sceneTools/daEditorX/Occluders/occluder.h
@@ -12,9 +12,10 @@ public:
   static constexpr unsigned HUID = 0x5177B0EEu; // occplugin::Occluder
 
 public:
+  EO_IMPLEMENT_RTTI(HUID, RenderableEditableObject)
+  
   Occluder(bool box_occluder);
   Occluder(const Occluder &);
-
 
   virtual void update(float);
 
@@ -41,9 +42,6 @@ public:
   virtual bool mayDelete() { return true; }
 
   virtual void onAdd(ObjectEditor *objEditor);
-
-  EO_IMPLEMENT_RTTI(HUID)
-
 
   bool isBox() const { return box; }
   bool getQuad(Point3 v[4]);

--- a/prog/tools/sceneTools/daEditorX/csg/box_csg.h
+++ b/prog/tools/sceneTools/daEditorX/csg/box_csg.h
@@ -11,9 +11,10 @@ public:
   static constexpr unsigned HUID = 0x5177B0EEu; // occplugin::Occluder
 
 public:
+  EO_IMPLEMENT_RTTI(HUID, RenderableEditableObject)
+  
   BoxCSG();
   BoxCSG(const BoxCSG &);
-
 
   virtual void update(float);
 
@@ -40,9 +41,6 @@ public:
   virtual bool mayDelete() { return true; }
 
   virtual void onAdd(ObjectEditor *objEditor);
-
-  EO_IMPLEMENT_RTTI(HUID)
-
 
   bool isBox() const { return box; }
   bool getQuad(Point3 v[4]);

--- a/prog/tools/sharedInclude/EditorCore/ec_camera_elem.h
+++ b/prog/tools/sharedInclude/EditorCore/ec_camera_elem.h
@@ -177,7 +177,7 @@ class FreeCameraElem : public CCameraElem
 {
 public:
   FreeCameraElem() : CCameraElem(FREE_CAMERA) {}
-  virtual void actInternal() { __super::actInternal(); }
+  virtual void actInternal() { CCameraElem::actInternal(); }
 };
 
 class MaxCameraElem : public CCameraElem

--- a/prog/tools/sharedInclude/EditorCore/ec_object.h
+++ b/prog/tools/sharedInclude/EditorCore/ec_object.h
@@ -16,14 +16,14 @@
 ///     @b false in other case\n
 /// virtual DClassID @b getClassId () - Returns class ID
 /// @ingroup EditorCore
-#define EO_IMPLEMENT_RTTI(id)                    \
+#define EO_IMPLEMENT_RTTI(id, base)              \
   static DClassID getStaticClassId()             \
   {                                              \
     return id;                                   \
   }                                              \
   virtual bool isSubOf(DClassID cid)             \
   {                                              \
-    return cid == (id) || __super::isSubOf(cid); \
+    return cid == (id) || base::isSubOf(cid); \
   }                                              \
   virtual DClassID getClassId()                  \
   {                                              \

--- a/prog/tools/sharedInclude/EditorCore/ec_rendEdObject.h
+++ b/prog/tools/sharedInclude/EditorCore/ec_rendEdObject.h
@@ -38,7 +38,7 @@ static const int CID_RenderableEditableObject = 0x6437E6D5;
 class RenderableEditableObject : public EditableObject
 {
 public:
-  EO_IMPLEMENT_RTTI(CID_RenderableEditableObject)
+  EO_IMPLEMENT_RTTI(CID_RenderableEditableObject, EditableObject)
 
   /// Object flags.
   enum RenderableEditableObjectFlags


### PR DESCRIPTION
I was considering trying to get a couple of these utilities working on linux. I don't think the __super extension is available for g++ so I think its a good early step to resolve these compiler errors. I prefer the more explicit calls, it's a lot easier to understand without trying to figure out how this squares with multi inheritance.

https://gcc.gnu.org/legacy-ml/gcc/2004-08/msg01276.html