### PR TITLE
🐛 Fixed build_all.cmd error in other language environments

### DIFF
--- a/build_all.cmd
+++ b/build_all.cmd
@@ -1,3 +1,5 @@
+set CL=/utf-8
+
 pushd prog\tools
 call build_dagor3_cdk_mini.cmd
 if errorlevel 1 (

--- a/prog/3rdPartyLibs/binPack2D/include/GuillotineBinPack.h
+++ b/prog/3rdPartyLibs/binPack2D/include/GuillotineBinPack.h
@@ -1,5 +1,5 @@
 /** @file GuillotineBinPack.h
-	@author Jukka Jylänki
+	@author Jukka Jylanki
 
 	@brief Implements different bin packer algorithms that use the GUILLOTINE data structure.
 

--- a/prog/3rdPartyLibs/binPack2D/include/MaxRectsBinPack.h
+++ b/prog/3rdPartyLibs/binPack2D/include/MaxRectsBinPack.h
@@ -1,5 +1,5 @@
 /** @file MaxRectsBinPack.h
-	@author Jukka Jylänki
+	@author Jukka Jylanki
 
 	@brief Implements different bin packer algorithms that use the MAXRECTS data structure.
 

--- a/prog/3rdPartyLibs/binPack2D/include/Rect.h
+++ b/prog/3rdPartyLibs/binPack2D/include/Rect.h
@@ -1,5 +1,5 @@
 /** @file Rect.h
-	@author Jukka Jylänki
+	@author Jukka Jylanki
 
 	This work is released to Public Domain, do whatever you want with it.
 */

--- a/prog/3rdPartyLibs/binPack2D/include/SkylineBinPack.h
+++ b/prog/3rdPartyLibs/binPack2D/include/SkylineBinPack.h
@@ -1,5 +1,5 @@
 /** @file SkylineBinPack.h
-	@author Jukka Jylänki
+	@author Jukka Jylanki
 
 	@brief Implements different bin packer algorithms that use the SKYLINE data structure.
 

--- a/prog/3rdPartyLibs/binPack2D/src/GuillotineBinPack.cpp
+++ b/prog/3rdPartyLibs/binPack2D/src/GuillotineBinPack.cpp
@@ -1,5 +1,5 @@
 /** @file GuillotineBinPack.cpp
-	@author Jukka Jylänki
+	@author Jukka Jylanki
 
 	@brief Implements different bin packer algorithms that use the GUILLOTINE data structure.
 

--- a/prog/3rdPartyLibs/binPack2D/src/MaxRectsBinPack.cpp
+++ b/prog/3rdPartyLibs/binPack2D/src/MaxRectsBinPack.cpp
@@ -1,5 +1,5 @@
 /** @file MaxRectsBinPack.cpp
-	@author Jukka Jylänki
+	@author Jukka Jylanki
 
 	@brief Implements different bin packer algorithms that use the MAXRECTS data structure.
 

--- a/prog/3rdPartyLibs/binPack2D/src/SkylineBinPack.cpp
+++ b/prog/3rdPartyLibs/binPack2D/src/SkylineBinPack.cpp
@@ -1,5 +1,5 @@
 /** @file SkylineBinPack.cpp
-	@author Jukka Jylänki
+	@author Jukka Jylanki
 
 	@brief Implements different bin packer algorithms that use the SKYLINE data structure.
 

--- a/prog/tools/converters/t3d2dag/t3dLoader.cpp
+++ b/prog/tools/converters/t3d2dag/t3dLoader.cpp
@@ -165,7 +165,7 @@ void CreateBmp24(char *fname, RGBTRIPLE *color, int u_size, int v_size)
   BITMAPINFOHEADER bih;
   BYTE Palette[1024]; // Палитра
 
-  // Пусть у нас будет картинка размером 35 x 50 пикселей
+  // Пусть у нас буaет картинка размером 35 x 50 пикселей
   int Width = u_size;
   int Height = v_size;
   memset(Palette, 0, 1024); // В палитре у нас нули
@@ -173,7 +173,7 @@ void CreateBmp24(char *fname, RGBTRIPLE *color, int u_size, int v_size)
   // Заполним их
   memset(&bfh, 0, sizeof(bfh));
   bfh.bfType = 0x4D42;                              // Обозначим, что это bmp 'BM'
-  bfh.bfOffBits = sizeof(bfh) + sizeof(bih) + 1024; // Палитра занимает 1Kb, но мы его испоьзовать не будем
+  bfh.bfOffBits = sizeof(bfh) + sizeof(bih) + 1024; // Палитра занимает 1Kb, но мы его испоьзовать не буaем
   bfh.bfSize = bfh.bfOffBits + sizeof(color[0]) * Width * Height + Height * (Width % 4); // Посчитаем размер конечного файла
 
   memset(&bih, 0, sizeof(bih));

--- a/prog/tools/libTools/propPanel2/panelControls/p_toolbar.cpp
+++ b/prog/tools/libTools/propPanel2/panelControls/p_toolbar.cpp
@@ -11,7 +11,7 @@ CToolbar::CToolbar(ControlEventHandler *event_handler, PropertyContainerControlB
   const char *caption) :
   PropertyContainerControlBase(id, event_handler, parent, x, y, w, _pxScaled(DEFAULT_TOOLBAR_HEIGHT)),
   mContainer(this, parent->getWindow(), x, y, _px(w), _pxS(DEFAULT_TOOLBAR_HEIGHT)),
-  mToolbar(this, &mContainer, 0, -_pxS(2) /* -2 для скрытия линии над тулбаром */, _px(w), _pxS(DEFAULT_TOOLBAR_BUTTON_HEIGHT),
+  mToolbar(this, &mContainer, 0, -_pxS(2) /* -2 aля скрытия линии наa тулбаром */, _px(w), _pxS(DEFAULT_TOOLBAR_BUTTON_HEIGHT),
     caption)
 {}
 


### PR DESCRIPTION
# Overview
Currently, when build_all.cmd is executed in another language environment (e.g. Japanese), a compile error may occur.

This PR is designed to solve that compile error.

# Cause
The reason for the error is that Cyrillic characters cannot be used in other language environments that use non-Unicode.

The code page used by the compiler depends on the system locale by default, and most Japanese environments use `CP932` for code pages.
This may be different in other countries.

# Changes
The following modifications have been made to resolve these problems.

- Set the environment variable `CL=/utf-8` to fix the codepage used by the compiler to `UTF-8`
- Replace the character `ä`, which is not `UTF-8` compatible, with `a`

I am not sure if the fix is appropriate, so please check and let me know.
