### PR TITLE
Fixed Python3.3 support breakage with `sys.platform` being 'linux2' prior to Python3.3

### DIFF
--- a/make_devtools.py
+++ b/make_devtools.py
@@ -20,9 +20,9 @@ if len(sys.argv) != 2:
   print('\nUsage: make_devtools.py DEVTOOLS_DEST_DIR\nexample: python3 make_devtools.py d:\\devtools\n')
   exit(1)
 
-if sys.platform == 'darwin':
+if sys.platform.startswith('darwin'):
   exit(exec(open(os.path.join(os.path.dirname(__file__), "make_devtools_macOS.py")).read()))
-elif sys.platform == 'linux':
+elif sys.platform.startswith('linux'):
   exit(exec(open(os.path.join(os.path.dirname(__file__), "make_devtools_linux.py")).read()))
 
 def error(s):

--- a/make_devtools_linux.py
+++ b/make_devtools_linux.py
@@ -4,7 +4,7 @@ import sys
 if sys.version_info.major < 3:
   print("\nERROR: Python 3 or a higher version is required to run this script.")
   exit(1)
-if sys.platform != 'linux':
+if not sys.platform.startswith('linux'):
   print("\nERROR: script is expected to be run on linux.")
   exit(1)
 

--- a/make_devtools_macOS.py
+++ b/make_devtools_macOS.py
@@ -4,7 +4,7 @@ import sys
 if sys.version_info.major < 3:
   print("\nERROR: Python 3 or a higher version is required to run this script.")
   exit(1)
-if sys.platform != 'darwin':
+if not sys.platform.startswith('darwin'):
   print("\nERROR: script is expected to be run on macOS.")
   exit(1)
 


### PR DESCRIPTION
Fixes issue #77
> When identifying linux this is used:
> 
> ```python
> sys.platform == 'linux'
> ```
> 
> but it fails for versions prior to python 3.3 since `sys.platform` used to include the kernel version, which was removed in python 3.3 which can be seen here: https://bugs.python.org/issue12326
> 
> The standard usage which is documented here is to replace it with `sys.platform.startswith('linux')` not only for linux, both other OSes as well, which provides better backwards and forward compatibility, and also means better support for other platforms (e.g. bsd): https://docs.python.org/3/library/sys.html#sys.platform
> 
> Unrelated Question: Will bsd support ever come to the DagorEngine?

including replacing other instances of `sys.platform == *` (even for those not comparing against linux) with the standard `sys.platform.startswith(*)`