### PR TITLE
Added reference for which build file to call on different OSes

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,12 @@ X:\develop\DagorEngine\samples\testGI\game
 
 To build the "testGI" sample, navigate to the X:\develop\DagorEngine\samples\testGI\prog folder and run the "jam" command. After building, the executable file will be placed in the testGI\game folder.
 
-Run DagorEngine/build_all.cmd to build the entire project toolkit from the source code. This process may take a considerable amount of time.
+Run `build_all`:
+- Windows: DagorEngine/build_all.cmd
+- MacOS: DagorEngine/build_all_macOS.sh
+- Linux: DagorEngine/build_all_linux.sh
+
+This builds the entire project toolkit from the source code. This process may take a considerable amount of time.
 
 ## Open-source roadmap
 


### PR DESCRIPTION
Unlike [make_devtools.py](https://github.com/RandomGamingDev/DagorEngine/blob/better-os-support/make_devtools.py) which supports all the supported OSes (Windows, MacOS, and Linux) [build_all.cmd](https://github.com/RandomGamingDev/DagorEngine/blob/better-os-support/build_all.cmd) despite being the only `build_all` mentioned in the README only works on Windows.

This PR adds references to the other scripts to be more accurate to the added multi-OS support and minimize confusion:
>Run build_all:
>
>- Windows: DagorEngine/build_all.cmd
>- MacOS: DagorEngine/build_all_macOS.sh
>- Linux: DagorEngine/build_all_linux.sh
>
>This builds the entire project toolkit from the source code. This process may take a considerable amount of time.

However, before this PR gets accepted should we consider writing a `Python` file just like `make_devtools.py` which supports all OSes? I think that that'd be the better choice compared to just updating the docs.