### PR TITLE
properly initialize data structure for SOAP parsing in ParseNameValue()

### DIFF
--- a/prog/3rdPartyLibs/miniupnpc/upnpreplyparse.c
+++ b/prog/3rdPartyLibs/miniupnpc/upnpreplyparse.c
@@ -1,7 +1,8 @@
 /* $Id: upnpreplyparse.c,v 1.19 2015/07/15 10:29:11 nanard Exp $ */
-/* MiniUPnP project
+/* vim: tabstop=4 shiftwidth=4 noexpandtab
+ * MiniUPnP project
  * http://miniupnp.free.fr/ or http://miniupnp.tuxfamily.org/
- * (c) 2006-2015 Thomas Bernard
+ * (c) 2006-2017 Thomas Bernard
  * This software is subject to the conditions detailed
  * in the LICENCE file provided within the distribution */
 
@@ -104,9 +105,7 @@ ParseNameValue(const char * buffer, int bufsize,
                struct NameValueParserData * data)
 {
 	struct xmlparser parser;
-	data->l_head = NULL;
-	data->portListing = NULL;
-	data->portListingLength = 0;
+	memset(data, 0, sizeof(struct NameValueParserData));
 	/* init xmlparser object */
 	parser.xmlstart = buffer;
 	parser.xmlsize = bufsize;


### PR DESCRIPTION
**Description**
This PR fixes a security vulnerability in ParseNameValue() that was cloned from miniupnp but did not receive the security patch. The original issue was reported and fixed under [miniupnp/miniupnp@7aeb624](https://github.com/miniupnp/miniupnp/commit/7aeb624b44f86d335841242ff427433190e7168a). This PR applies the same patch to eliminate the vulnerability.

References
https://nvd.nist.gov/vuln/detail/CVE-2017-1000494
https://github.com/miniupnp/miniupnp/commit/7aeb624b44f86d335841242ff427433190e7168a